### PR TITLE
Dockerfile: Switch from Alpine to Debian Buster (slim)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     git \
     libffi-dev \
     libjpeg-dev \
-    libjpeg-turbo-dev \
+    libjpeg62-turbo-dev \
     libwebp-dev \
     linux-headers-amd64 \
     musl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-slim-buster
 
-RUN apt update && apt upgrade -y && \
+RUN apt update; apt upgrade -y; \
     apt install -y \
     bash \
     curl \
@@ -28,5 +28,6 @@ RUN rsync --ignore-existing --recursive /tmp/userbot_local/ /usr/src/app/Paperpl
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install --no-warn-script-location --no-cache-dir --upgrade -r requirements.txt
 
-RUN rm -rf /tmp/* /var/lib/apt/lists/*
+RUN apt clean; apt autoclean
+RUN rm -rf /tmp/* /var/lib/apt/lists/* /var/cache/apt/archives/*
 CMD ["python", "-m", "userbot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt update && apt upgrade -y && \
     gcc \
     git \
     libffi-dev \
-    libjpeg62-dev \
+    libjpeg-dev \
     libjpeg62-turbo-dev \
     libwebp-dev \
     linux-headers-amd64 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-slim-buster
 
-RUN apt update && apt upgrade && \
+RUN apt update && apt upgrade -y && \
     apt install -y \
     bash \
     curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
     gcc \
     git \
     libffi-dev \
-    libjpeg \
+    libjpeg-dev \
     libjpeg-turbo-dev \
     libwebp-dev \
     linux-headers \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,13 @@ RUN apt-get update && apt-get install -y \
     libjpeg-dev \
     libjpeg-turbo-dev \
     libwebp-dev \
-    linux-headers \
+    linux-headers-amd64 \
     musl \
     musl-dev \
     neofetch \
     rsync \
-    zlib \
-    zlib-dev
+    zlib1g \
+    zlib1g-dev
 
 COPY . /tmp/userbot_local
 WORKDIR /usr/src/app/PaperplaneRemix/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM python:3.8-slim-buster
 
-RUN apt-get update && apt-get install -y \
+RUN apt update && apt upgrade && \
+    apt install -y \
     bash \
     curl \
     ffmpeg \
     gcc \
     git \
     libffi-dev \
-    libjpeg-dev \
+    libjpeg62-dev \
     libjpeg62-turbo-dev \
     libwebp-dev \
     linux-headers-amd64 \
@@ -27,5 +28,5 @@ RUN rsync --ignore-existing --recursive /tmp/userbot_local/ /usr/src/app/Paperpl
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install --no-warn-script-location --no-cache-dir --upgrade -r requirements.txt
 
-RUN rm -rf /var/cache/apk/* /tmp/*
+RUN rm -rf /tmp/* /var/lib/apt/lists/*
 CMD ["python", "-m", "userbot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.8-alpine
+FROM python:3.8-slim-buster
 
-RUN apk add --no-cache --update \
+RUN apt-get update && apt-get install -y \
     bash \
     curl \
     ffmpeg \


### PR DESCRIPTION
Alpine is bad for Python: https://pythonspeed.com/articles/alpine-docker-python/
Debian Buster/Ubuntu is better: https://pythonspeed.com/articles/base-image-python-docker-images/

Kudos to @penn5 for the info.